### PR TITLE
Remove duplicate discovery helper definition

### DIFF
--- a/copy-csh.js
+++ b/copy-csh.js
@@ -535,21 +535,4 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   attachButtonListener();
-
-  // ---------- inner helpers (defined after first use for clarity) ----------
-  async function discoverFlareContextWithInline() {
-    const cfg = getInlineConfig();
-    if (cfg.useCustomSettings && (cfg.basePath || cfg.aliasPath)) {
-      const base = cfg.basePath || "/";
-      const alias = cfg.aliasPath || (base === "/" ? "/Data/Alias.xml" : base.replace(/\/+$/,"") + "/Data/Alias.xml");
-      const ctx = finalizeFromBaseAndAlias(base, alias);
-      ctx._defaultExt = cfg.defaultExt || "htm";
-      if (typeof cfg.logLevel === "number") logLevel = cfg.logLevel;
-      log(1, "Using inline settings:", { basePath: ctx.basePath, aliasPath: ctx.aliasPath, defaultExt: ctx._defaultExt });
-      return ctx;
-    }
-    const ctx = await discoverFlareContextAutoprobe();
-    ctx._defaultExt = "htm";
-    return ctx;
-  }
 });


### PR DESCRIPTION
## Summary
- remove the duplicate discoverFlareContextWithInline helper so only one definition is used
- keep context discovery logic centralized for clipboard URL handling

## Testing
- node --check copy-csh.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d2f8da7883299e63bbf860817d15)